### PR TITLE
Navbar-change-added-dashboard-link

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,11 +12,12 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
+          <li class=<%= current_class?(user_path(current_user)) %>>
+            <%= link_to "Dashboard", user_path(current_user), class: "nav-link link-colour" %>
+          </li>
         <li class="nav-item dropdown">
-          <!-- need to link to cloudinary -->
           <%= cl_image_tag current_user.photo, width: 40, height: 40, crop: :thumb, gravity: :face, class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <!-- create an 'Edit profile' section -->
             <%= link_to "Edit Profile", edit_user_registration_path, class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>


### PR DESCRIPTION
added the dashboard link back into the navbar to ensure that the user can navigate back to the dashboard from any page other than the landing page